### PR TITLE
Support for instance profiles

### DIFF
--- a/bedrock_fm/__init__.py
+++ b/bedrock_fm/__init__.py
@@ -31,6 +31,7 @@ from .bedrock import (
     BedrockFoundationModel,
     BedrockEmbeddingsModel,
     EmbeddingType,
+    InstanceProfile,
 )
 from .bedrock_image import BedrockImageModel
 from attrs import field
@@ -74,6 +75,7 @@ __all__ = [
     "Assistant",
     "System",
     "EmbeddingType",
+    "InstanceProfile",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bedrock_fm"
-version = "0.4.11"
+version = "0.4.12"
 authors = [ "Massimiliano Angelino" ]
 description = "A package to simplify interaction with Bedrock Foundation models"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bedrock_fm"
-version = "0.4.12"
+version = "0.4.13"
 authors = [ "Massimiliano Angelino" ]
 description = "A package to simplify interaction with Bedrock Foundation models"
 readme = "README.md"
@@ -34,5 +34,5 @@ ipykernel = "^6.27.1"
 pdoc = {version = "^14.1.0", optional = true}
 
 [project.urls]
-"Homepage" = "https://github.com/aws-samples"
-"Bug Tracker" = "https://github.com/aws-samples"
+"Homepage" = "https://github.com/mirai73/bedrock-fm"
+"Bug Tracker" = "https://github.com/mirai73/bedrock-fm"

--- a/tests/test_meta_llama3_2.py
+++ b/tests/test_meta_llama3_2.py
@@ -2,6 +2,7 @@ from bedrock_fm import (
     Llama3Instruct,
     Model,
     CompletionDetails,
+    InstanceProfile,
     Model,
     Human,
     System,
@@ -11,7 +12,9 @@ from bedrock_fm.exceptions import BedrockExtraArgsError, BedrockInvocationError
 import pytest
 import json
 
-fm = Llama3Instruct.from_id(Model.META_LLAMA3_8B_INSTRUCT_V1_0)
+fm = Llama3Instruct.from_id(
+    Model.META_LLAMA3_2_1B_INSTRUCT_V1_0, instance_profile=InstanceProfile.US
+)
 
 
 def test_args():


### PR DESCRIPTION
With this PR we add support for instance profiles. Some models,  like Llama 3.2 can only be used via Instance Profiles.
In order to configure an instance profile use the parameter `instance_profile` when you create your model using `from_id` method. The class `InstanceProfile` defines the supported profiles `US` and `EU`.